### PR TITLE
Fix scaling on steering and imu reports

### DIFF
--- a/dbw_pacifica_can/src/DbwNode.cpp
+++ b/dbw_pacifica_can/src/DbwNode.cpp
@@ -273,8 +273,8 @@ void DbwNode::recvCAN(const can_msgs::Frame::ConstPtr& msg)
 
           dbw_pacifica_msgs::SteeringReport steeringReport;
           steeringReport.header.stamp = msg->header.stamp;
-          steeringReport.steering_wheel_angle = message->GetSignal("DBW_SteeringWhlAngleAct")->GetResult() * (0.1 * M_PI / 180);
-          steeringReport.steering_wheel_angle_cmd = message->GetSignal("DBW_SteeringWhlAngleDes")->GetResult() * (0.1 * M_PI / 180);
+          steeringReport.steering_wheel_angle = message->GetSignal("DBW_SteeringWhlAngleAct")->GetResult() * (M_PI / 180);
+          steeringReport.steering_wheel_angle_cmd = message->GetSignal("DBW_SteeringWhlAngleDes")->GetResult() * (M_PI / 180);
           steeringReport.steering_wheel_torque = message->GetSignal("DBW_SteeringWhlPcntTrqCmd")->GetResult() * 0.0625;
 
           steeringReport.enabled = message->GetSignal("DBW_SteeringEnabled")->GetResult() ? true : false;
@@ -462,7 +462,7 @@ void DbwNode::recvCAN(const can_msgs::Frame::ConstPtr& msg)
           out.header.stamp = msg->header.stamp;
           out.header.frame_id = frame_id_;
 
-          out.angular_velocity.z = (double)message->GetSignal("DBW_ImuYawRate")->GetResult();
+          out.angular_velocity.z = (double)message->GetSignal("DBW_ImuYawRate")->GetResult() * (M_PI / 180.0);
 
           out.linear_acceleration.x = (double)message->GetSignal("DBW_ImuAccelX")->GetResult();
           out.linear_acceleration.y = (double)message->GetSignal("DBW_ImuAccelY")->GetResult();


### PR DESCRIPTION
When the desired and actual steering wheel angles for the steering report are converted from degrees to radians, they are incorrectly also multiplied by 0.1.  Looking at the DBC file I see the scaling for them is 0.1 degrees, however, the GetSignal/GetResult call is taking care of that.

Also, the yaw rate should be converted from degrees to radians.

There's also the road slope estimate in a couple of places that may need to be converted from degrees to radians, but I wasn't exactly sure what that means so I couldn't test it.

I did try testing the steering command angle velocity limit, since I thought it was odd that it's being divided by 2 while converting it from radians to degrees, however, even with it set really low it didn't seem to be having any effect.
