### PR TITLE
Adding missing dependencies to CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,10 @@ jobs:
           name: Set Up Container
           command: |
             apt-get update -qq
+            apt-get install -y software-properties-common
+            apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
+            apt-get update -qq
+            apt-get install kvaser-canlib-dev
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep update
             rosdep install --from-paths . --ignore-src -y
@@ -38,6 +42,10 @@ jobs:
           name: Set Up Container
           command: |
             apt-get update -qq
+            apt-get install -y software-properties-common
+            apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
+            apt-get update -qq
+            apt-get install kvaser-canlib-dev
             source `find /opt/ros -name setup.bash | sort | head -1`
             rosdep update
             rosdep install --from-paths . --ignore-src -y


### PR DESCRIPTION
The dependencies for `kvaser_interface` have changed. This adds the missing dependency on `kvaser-canlib-dev` from my PPA.