### PR TITLE
Updated Autonomous Stuff PPA address

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           command: |
             apt-get update -qq
             apt-get install -y software-properties-common
-            apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
+            apt-add-repository -y ppa:astuff/kvaser-linux
             apt-get update -qq
             apt-get install kvaser-canlib-dev
             source `find /opt/ros -name setup.bash | sort | head -1`
@@ -43,7 +43,7 @@ jobs:
           command: |
             apt-get update -qq
             apt-get install -y software-properties-common
-            apt-add-repository -y ppa:jwhitleyastuff/kvaser-linux
+            apt-add-repository -y ppa:astuff/kvaser-linux
             apt-get update -qq
             apt-get install kvaser-canlib-dev
             source `find /opt/ros -name setup.bash | sort | head -1`


### PR DESCRIPTION
Copying the astuff commit: https://github.com/astuff/kvaser_interface/commit/242903aadde109bf53610b379d7beae0e7731d0f

Needed to install kvaser_interface in circle.ci.