### PR TITLE
Add install directive for .dbc file

### DIFF
--- a/raptor_dbw_can/CMakeLists.txt
+++ b/raptor_dbw_can/CMakeLists.txt
@@ -65,6 +65,10 @@ install(DIRECTORY launch
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+install(FILES New_Eagle_DBW_3.3.388.dbc
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 if (CATKIN_ENABLE_TESTING)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
Resolves issue #17 by adding an install directive for the dbc file.
This is a recreation of #18 after the folder structure renaming broke the git merge. 