### PR TITLE
Fix missing dependency on can_msgs

### DIFF
--- a/can_dbc_parser/CMakeLists.txt
+++ b/can_dbc_parser/CMakeLists.txt
@@ -2,10 +2,13 @@ cmake_minimum_required(VERSION 2.8.3)
 project(can_dbc_parser)
 
 find_package(catkin REQUIRED COMPONENTS
+  can_msgs
   roscpp
 )
 
 catkin_package(
+  CATKIN_DEPENDS
+    can_msgs
   INCLUDE_DIRS
     include
   LIBRARIES

--- a/can_dbc_parser/CMakeLists.txt
+++ b/can_dbc_parser/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
   CATKIN_DEPENDS
     can_msgs
+    roscpp
   INCLUDE_DIRS
     include
   LIBRARIES

--- a/can_dbc_parser/package.xml
+++ b/can_dbc_parser/package.xml
@@ -13,5 +13,6 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>can_msgs</depend>
   <depend>roscpp</depend>
 </package>


### PR DESCRIPTION
It's included here but not depended upon:
https://github.com/NewEagleRaptor/raptor-dbw-ros/blob/f50f91cd88ad27b2ce05bab1f8ff780931c41475/can_dbc_parser/include/can_dbc_parser/DbcMessage.h#L39